### PR TITLE
The 'http:' part of links should be removed.

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,9 +17,9 @@
 	
 	<!-- Fonts -->
 
-	<link href='http://fonts.googleapis.com/css?family=Lobster' rel='stylesheet' type='text/css'>
-	<link href='http://fonts.googleapis.com/css?family=Monda' rel='stylesheet' type='text/css'>
-	<link href='http://fonts.googleapis.com/css?family=Shojumaru' rel='stylesheet' type='text/css'>
+	<link href='//fonts.googleapis.com/css?family=Lobster' rel='stylesheet' type='text/css'>
+	<link href='//fonts.googleapis.com/css?family=Monda' rel='stylesheet' type='text/css'>
+	<link href='//fonts.googleapis.com/css?family=Shojumaru' rel='stylesheet' type='text/css'>
 	
 	<!-- Favicon -->
 	
@@ -141,12 +141,12 @@
 	</section>
 
 	<footer id="footer" class="section section-dark">
-		<a rel="license" href="http://creativecommons.org/licenses/by/3.0/deed.en_US"><img alt="Creative Commons License" style="border-width:0" src="http://i.creativecommons.org/l/by/3.0/88x31.png"></a>
+		<a rel="license" href="http://creativecommons.org/licenses/by/3.0/deed.en_US"><img alt="Creative Commons License" style="border-width:0" src="//i.creativecommons.org/l/by/3.0/88x31.png"></a>
 	</footer>
 
-	<script src="http://code.jquery.com/jquery.js"></script>
+	<script src="//code.jquery.com/jquery.js"></script>
 	<script src="js/bootstrap.min.js"></script>
-	<script src="http://www.parsecdn.com/js/parse-1.2.7.min.js"></script>
+	<script src="//www.parsecdn.com/js/parse-1.2.7.min.js"></script>
 	<script src="js/main.js"></script>
 
 	<script>


### PR DESCRIPTION
This is so that the page will load the https versions if a user visits using https. As of now, visiting the page over https will bring up an unsafe script prompt and will refuse to load the css/js.
